### PR TITLE
Update deploy script to ignore modtime

### DIFF
--- a/scripts/local_build_deploy.sh
+++ b/scripts/local_build_deploy.sh
@@ -14,4 +14,4 @@ export CURDIR="$(pwd)"
 
 cd tests/config && hugo --gc --minify -b $BASEURL --source "$(pwd)" --destination "${TARGET}" --config "${SITECONFIG}"
 cd "${CURDIR}"
-rclone sync --progress public/ wtg-modstarter:./
+rclone sync --checksum --progress public/ wtg-modstarter:./


### PR DESCRIPTION
Use checksum only due to modtime issues on the hosting

Signed-off-by: Daniel F. Dickinson <dfdpublic@wildtechgarden.ca>